### PR TITLE
Un-remove the parts required to add Python docs to pyslang

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ jobs:
           -not \( -name css -o -name documentation -o -name plugins \) \
           -exec rm -rf {} +
         find css -maxdepth 1 -mindepth 1 -not -name '*.compiled.css' -delete
-        rm -rf documentation/templates/python documentation/test* \
-          documentation/.* documentation/{__init__,python}.py \
+        rm -rf documentation/test* \
+          documentation/.* \
           plugins/.coveragerc plugins/m/{test,.gitignore,__init__.py} || :
         cmake -E tar cf mcss.zip --format=zip $(ls)
     - name: Release


### PR DESCRIPTION
Aside - I was convinced I was losing my mind trying to figure out why your downloaded release didn't have the files that were very clearly in m.css upstream repo and very clearly in your repo. Removing files during the release step is one heck of a power move (awful to figure out if you don't know it's a thing you can do though).

Anyway, please merge this and tag a release so I can keep going with this pyslang PR - https://github.com/MikePopoloski/slang/pull/1218